### PR TITLE
To use firebase in react native the dom api dependency needed to be removed

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -5,9 +5,7 @@
   "sources": [
     "src"
   ],
-  "bs-dependencies" : [
-    "bs-webapi",
-  ],
+  "bs-dependencies" : [],
   "package-specs": [
     {
       "module": "commonjs",

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "0.1.0",
   "scripts": {
     "clean": "bsb -clean-world",
-    "build": "bsb -make-world",
-    "watch": "bsb -make-world -w"
+    "build": "bsb -make-world -clean-world",
+    "watch": "bsb -make-world -clean-world -w"
   },
   "keywords": [
     "BuckleScript"
@@ -14,7 +14,7 @@
     "bs-platform": "^2.0.0"
   },
   "dependencies": {
-    "bsb": "^0.0.1",
+    "bs-platform": "^2.1.0",
     "firebase": "^4.4.0",
     "global": "^4.3.2"
   },

--- a/package.json
+++ b/package.json
@@ -11,11 +11,12 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "bs-platform": "^2.0.0",
-    "bs-webapi": "git+https://github.com/viskahq/bs-webapi-incubator.git"
+    "bs-platform": "^2.0.0"
   },
   "dependencies": {
-    "firebase": "^4.4.0"
+    "bsb": "^0.0.1",
+    "firebase": "^4.4.0",
+    "global": "^4.3.2"
   },
   "repository": "git@github.com:viskahq/bs-firebase.git",
   "author": ""

--- a/src/reasonFirebase.re
+++ b/src/reasonFirebase.re
@@ -1,5 +1,3 @@
-open BsWebapi.Webapi.Dom;
-
 module Error = {
   type t('e) = Js.t('e);
 };

--- a/src/reasonFirebase.re
+++ b/src/reasonFirebase.re
@@ -107,7 +107,7 @@ module Storage = {
     [@bs.send] external path : (t, ~path: string) => t = "";
     [@bs.send]
     external put :
-      (t, ~data: Window.File.t, ~metadata: Js.t('a)=?, unit) => Js.Promise.t(UploadTask.t) =
+      (t, ~data: Js.Array.t(int), ~metadata: Js.t('a)=?, unit) => Js.Promise.t(UploadTask.t) =
       "";
     [@bs.send] external delete : t => Js.Promise.t(unit) = "";
     [@bs.send] external getDownloadURL : t => Js.Promise.t(string) = "";

--- a/yarn.lock
+++ b/yarn.lock
@@ -49,9 +49,9 @@
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/@firebase/webchannel-wrapper/-/webchannel-wrapper-0.2.3.tgz#e94f7e772f40e48a2dc52e57d1df38b28bf98e39"
 
-bsb@^0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/bsb/-/bsb-0.0.1.tgz#577d3a99afe5f32bcc6786745c333e12338b1b3a"
+bs-platform@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-2.1.0.tgz#63560ff8f7142c9c0631559df1c35590b9f6d8b2"
 
 dom-storage@^2.0.2:
   version "2.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -49,9 +49,17 @@
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/@firebase/webchannel-wrapper/-/webchannel-wrapper-0.2.3.tgz#e94f7e772f40e48a2dc52e57d1df38b28bf98e39"
 
+bsb@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/bsb/-/bsb-0.0.1.tgz#577d3a99afe5f32bcc6786745c333e12338b1b3a"
+
 dom-storage@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/dom-storage/-/dom-storage-2.0.2.tgz#ed17cbf68abd10e0aef8182713e297c5e4b500b0"
+
+dom-walk@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/dom-walk/-/dom-walk-0.1.1.tgz#672226dc74c8f799ad35307df936aba11acd6018"
 
 faye-websocket@0.9.3:
   version "0.9.3"
@@ -73,9 +81,26 @@ firebase@^4.4.0:
     dom-storage "^2.0.2"
     xmlhttprequest "^1.8.0"
 
+global@^4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/global/-/global-4.3.2.tgz#e76989268a6c74c38908b1305b10fc0e394e9d0f"
+  dependencies:
+    min-document "^2.19.0"
+    process "~0.5.1"
+
 http-parser-js@>=0.4.0:
   version "0.4.9"
   resolved "https://registry.yarnpkg.com/http-parser-js/-/http-parser-js-0.4.9.tgz#ea1a04fb64adff0242e9974f297dd4c3cad271e1"
+
+min-document@^2.19.0:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/min-document/-/min-document-2.19.0.tgz#7bd282e3f5842ed295bb748cdd9f1ffa2c824685"
+  dependencies:
+    dom-walk "^0.1.0"
+
+process@~0.5.1:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/process/-/process-0.5.2.tgz#1638d8a8e34c2f440a91db95ab9aeb677fc185cf"
 
 promise-polyfill@^6.0.2:
   version "6.0.2"


### PR DESCRIPTION
Firebase api in javascript has no such dependency either, it seems to be pretty platform agnostic.

Please test if this change will compile for you.
I'm following the firebase spec which says that the put data should be an array of ints, however I can imagine this will break stuff for you. Please tell me how to fix this properly then. 
I'm not sure how you use this.